### PR TITLE
Add workaround for links no longer working if text doesn't match href

### DIFF
--- a/src/messagebuilder.coffee
+++ b/src/messagebuilder.coffee
@@ -41,7 +41,11 @@ module.exports = class MessageBuilder
     italic: (txt) -> @text txt, false, true
     strikethrough: (txt) -> @text txt, false, false, true
     underline: (txt) -> @text txt, false, false, false, true
-    link: (txt, href) -> @text txt, false, false, false, false, href
+    link: (txt, href) ->
+        if txt != href
+            @text(txt + ' (', false, false, false, false).text(href, false, false, false, false, href).text(')', false, false, false, false)
+        else
+            @text txt, false, false, false, false, href
 
     linebreak: ->
         seg = [SegmentType.LINE_BREAK, '\n']

--- a/test/test-messagebuilder.coffee
+++ b/test/test-messagebuilder.coffee
@@ -31,9 +31,15 @@ describe 'MessageBuilder', ->
 
     it 'adds a link', ->
         deql mb.link('linktext', 'http://foo/bar').toSegments(),
-            [[2,'linktext',null,['http://foo/bar']]]
+            [[0, 'linktext ('], [2,'http://foo/bar',null,['http://foo/bar']], [0, ')']]
         deql mb.toSegsjson(),
-            [{link_data:{link_target:'http://foo/bar'},text:'linktext', type:'LINK'}]
+            [{type:'TEXT', text:'linktext ('}, {link_data:{link_target:'http://foo/bar'},text:'http://foo/bar', type:'LINK'}, {type:'TEXT', text:')'}]
+
+    it 'adds a plain link', ->
+        deql mb.link('http://foo/bar', 'http://foo/bar').toSegments(),
+            [[2,'http://foo/bar',null,['http://foo/bar']]]
+        deql mb.toSegsjson(),
+            [{link_data:{link_target:'http://foo/bar'},text:'http://foo/bar', type:'LINK'}]
 
     it 'adds a linebreak', ->
         deql mb.linebreak().toSegments(), [[1,'\n']]


### PR DESCRIPTION
See #53

This might be an opinionated change, but `.link` as is does not work.

This produces `test (http://google.com)` (with http://google.com clickable) for `.link('test', 'http://google.com')`
