### PR TITLE
adds optional argument to fetch metadata

### DIFF
--- a/src/client.coffee
+++ b/src/client.coffee
@@ -443,11 +443,11 @@ module.exports = class Client extends EventEmitter
     # This is mainly used for retrieving conversation
     # scrollback. Events occurring before timestamp are returned, in
     # order from oldest to newest.
-    getconversation: (conversation_id, timestamp, max_events=50) ->
+    getconversation: (conversation_id, timestamp, max_events=50, include_metadata = false) ->
         @chatreq.req('conversations/getconversation', [
             @_requestBodyHeader()
             [[conversation_id], [], []],  # conversationSpec
-            false,                        # includeConversationMetadata
+            include_metadata,             # includeConversationMetadata
             true,                         # includeEvents
             None,                         # ???
             max_events,                   # maxEventsPerConversation


### PR DESCRIPTION
Simple extension to getconversation method allowing the **retrieval of metadata, such as read_state**

see https://github.com/tdryer/hangups/issues/171

------------

**important, but not essential TODO that will break backwards compatibility**

- watermark and conversation_state objects have different names for the same data last_read_timestamp and latest_read_timestamp

Changing any of them might break applications that rely on hangupsjs

At this moment I can only think of YakYak (which won't suffer from this change as the devs are the same)