### PR TITLE
fix: Add withCredentials option to requests that need to send cookies

### DIFF
--- a/src/auth.coffee
+++ b/src/auth.coffee
@@ -188,6 +188,7 @@ module.exports = class Auth
                 jar: request.jar jarstore
                 proxy: opts.proxy
                 headers: headers
+                withCredentials: true
         .then (res) ->
             return Q.reject NetworkError.forRes(res) unless res.statusCode == 200
             log.debug 'got uberauth'
@@ -200,6 +201,7 @@ module.exports = class Auth
                 uri: MERGE_SESSION
                 jar: request.jar jarstore
                 proxy: opts.proxy
+                withCredentials: true
         .then (res) ->
             return Q.reject NetworkError.forRes(res) unless res.statusCode == 200
             log.debug 'request merge session 2/2'
@@ -209,6 +211,7 @@ module.exports = class Auth
                 jar: request.jar jarstore
                 proxy: opts.proxy
                 headers: headers
+                withCredentials: true
         .then (res) ->
             return Q.reject NetworkError.forRes(res) unless res.statusCode == 200
             log.debug 'got session cookies'

--- a/src/channel.coffee
+++ b/src/channel.coffee
@@ -75,6 +75,7 @@ module.exports = class Channel
             method: 'GET'
             uri: "#{ORIGIN_URL}/talkgadget/_/extension-start"
             jar: request.jar @jarstore
+            withCredentials: true
         req(opts).then (res) =>
             data = JSON.parse res.body
             log.debug 'found pvt token', data[1]
@@ -106,6 +107,7 @@ module.exports = class Channel
                     count: 0
                 headers: auth
                 encoding: null # get body as buffer
+                withCredentials: true
             req(opts).then (res) ->
                 # Example format (after parsing JS):
                 # [   [0,["c","SID_HERE","",8]],
@@ -211,6 +213,7 @@ module.exports = class Channel
             headers: @authHeaders()
             encoding: null # get body as buffer
             timeout: 30000 # 30 seconds timeout in connect attempt
+            withCredentials: true
         ok = false
         @currentReq = request(opts).on 'response', (res) =>
             log.debug 'long poll response', res.statusCode, res.statusMessage
@@ -266,6 +269,7 @@ module.exports = class Channel
                 headers: @authHeaders()
                 timeout: 30000 # 30 seconds timeout in connect attempt
                 form: formMap
+                withCredentials: true
             req(opts)
         .then (res) ->
             if res.statusCode == 200

--- a/src/chatreq.coffee
+++ b/src/chatreq.coffee
@@ -35,6 +35,7 @@ module.exports = class ChatReq
             body: if Buffer.isBuffer body then body else JSON.stringify(body)
             encoding: null # get body as buffer
             timeout: timeout # timeout in connect attempt (default 30 sec)
+            withCredentials: true
         req(opts).fail (err) ->
             log.debug 'request failed', err
             Q.reject err

--- a/src/init.coffee
+++ b/src/init.coffee
@@ -29,6 +29,7 @@ module.exports = class Init
             qs: params
             jar: request.jar jarstore
             proxy: @proxy
+            withCredentials: true
         req(opts).then (res) =>
             if res.statusCode == 200
                 @parseBody res.body


### PR DESCRIPTION
This option is needed when using hangupsjs in a browser environment (with Browserify) because by default the browser does not send the Cookie header (see #85).

This option is totally ignored by Nodejs.

(This won't make hangupsjs work in a standard browser but it allows it to work in a browser-like context without CORS like a Cordova app or an Electron renderer process.)