### PR TITLE
Lazy fix for Google adding nonce to their script tags.

### DIFF
--- a/src/init.coffee
+++ b/src/init.coffee
@@ -50,7 +50,7 @@ module.exports = class Init
             html = body.replace /<!DOCTYPE html><html>(.|\n)*<\/html>/gm, ''
 
             # and then the <script> tags
-            html = html.replace /<\/?script>/gm, ''
+            html = html.replace /<\/?script( nonce="(.*?)")?>/gm, ''
 
             # expose the init chunk queue
             html = html.replace 'var AF_initDataChunkQueue =',


### PR DESCRIPTION
Someone who actually knows how this works should really fix this properly, but this is a quick and dirty fix to just discard them and it seems to fix YakYak.