### PR TITLE
Fix the email field number

### DIFF
--- a/src/init.coffee
+++ b/src/init.coffee
@@ -72,7 +72,7 @@ module.exports = class Init
             #   { key: 'ds:3', isError: false, hash: '5', data: [Function] }...
             DICT =
                 apikey: { key:'ds:7',  fn: (d) -> d[0][2] }
-                email:  { key:'ds:36', fn: (d) -> d[0][2] }
+                email:  { key:'ds:33', fn: (d) -> d[0][2] }
                 headerdate:    { key:'ds:2', fn: (d) -> d[0][4] }
                 headerversion: { key:'ds:2', fn: (d) -> d[0][6] }
                 headerid:      { key:'ds:4', fn: (d) -> d[0][7] }


### PR DESCRIPTION
HangupsJS stopped working about an hour ago due to the changes in the HTML that Google returns and as result YakYak stopped working too.

Fixing the email field number in the "yakyak-linux-x64/resources/app/node_modules/hangupsjs/lib/init.js" from "ds:36" to "ds:33" seems to solve the problem, so I suppose changing it here in the "src/init.coffee" file should do the trick.

I think this will require a new binary release of YakYak too.
