### PR TITLE
Fix email and self_entity changing ids server-side. And initial conv list.

### DIFF
--- a/src/client.coffee
+++ b/src/client.coffee
@@ -89,6 +89,8 @@ module.exports = class Client extends EventEmitter
             # now intialize the chat using the pvt
             @init.initChat @jarstore, pvt
         .then =>
+            @initrecentconversations @init
+        .then =>
             @running = true
             @connected = false
             # ensure we have a fresh timestamp
@@ -479,6 +481,14 @@ module.exports = class Client extends EventEmitter
         ], false).then (body) -> # receive as protojson
             CLIENT_SYNC_ALL_NEW_EVENTS_RESPONSE.parse body
 
+    # Initializes the recent conversations.
+    initrecentconversations: (init) ->
+        @chatreq.req('conversations/syncrecentconversations', [
+            @_requestBodyHeader(),
+            null
+        ], false).then (body) -> # receive as protojson
+            data = CLIENT_SYNC_ALL_NEW_EVENTS_RESPONSE.parse body
+            init.conv_states = data.conversation_state
 
     # Search for people.
     searchentities: (search_string, max_results=10) ->

--- a/src/init.coffee
+++ b/src/init.coffee
@@ -72,15 +72,16 @@ module.exports = class Init
             #   { key: 'ds:3', isError: false, hash: '5', data: [Function] }...
             DICT =
                 apikey: { key:'ds:7',  fn: (d) -> d[0][2] }
-                email:  { key:'ds:36', fn: (d) -> d[0][2] }
+                email:  { key:'ds:31', fn: (d) -> d[0][2] }
                 headerdate:    { key:'ds:2', fn: (d) -> d[0][4] }
                 headerversion: { key:'ds:2', fn: (d) -> d[0][6] }
                 headerid:      { key:'ds:4', fn: (d) -> d[0][7] }
                 timestamp:     { key:'ds:20', fn: (d) -> new Date (d[0][1][4] / 1000) }
-                self_entity:   { key:'ds:21', fn: (d) ->
+                self_entity:   { key:'ds:20', fn: (d) ->
                     CLIENT_GET_SELF_INFO_RESPONSE.parse(d[0]).self_entity
                 }
                 conv_states: { key:'ds:20', fn: (d) ->
+                    # Removed in server-side update
                     CLIENT_CONVERSATION_STATE_LIST.parse(d[0][3])
                 }
 


### PR DESCRIPTION
As the title says, this fixes the ids of email and self_entity, as well as fixing conversation states no longer being sent in the init message by running sync after initializing.
Wasn't sure what to do about conv_states being initialized to ds:20 still, so I left it as it doesn't seem to do any harm.

This fixes #103 