### PR TITLE
Fix connection issues due to server changing data to an array

### DIFF
--- a/src/init.coffee
+++ b/src/init.coffee
@@ -92,10 +92,19 @@ module.exports = class Init
                         d = e.data()
                         if d? && d.length > 0 && d[0].length > 0 && d[0][0].length > 0
                             return spec.name == d[0][0]
+                    else if spec.name? && Array.isArray e.data
+                        d = e.data
+                        if d? && d.length > 0 && d[0].length > 0 && d[0][0].length > 0
+                            return spec.name == d[0][0]
                     spec.key == e.key
 
                 if ent
-                    this[k] = d = spec.fn ent.data()
+                    if typeof ent.data == 'function'
+                        data = ent.data()
+                    else
+                        data = ent.data
+
+                    this[k] = d = spec.fn data
                     if d.length
                         log.debug 'init data count', k, d.length
                     else


### PR DESCRIPTION
They changed the data parameter of AF_initDataChunkQueue to be an array instead of a function, which causes it to not parse the data properly. This fixes that (while also maintaining backwards compatibility if they, for some reason, revert it).