### PR TITLE
Don't add sources and travis to NPM package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -26,3 +26,6 @@ login.coffee
 jsdom
 test
 refreshtoken.txt
+
+src
+.travis.yml


### PR DESCRIPTION
This PR removes the src directory and the `.travis.yml` files from the NPM package.