### PR TITLE
Fix private token not loading anymore

### DIFF
--- a/src/channel.coffee
+++ b/src/channel.coffee
@@ -6,6 +6,7 @@ log     = require 'bog'
 Q       = require 'q'
 
 {req, find, wait, NetworkError, fmterr} = require './util'
+InitDataParser = require './initdataparser'
 PushDataParser = require './pushdataparser'
 
 ORIGIN_URL = 'https://hangouts.google.com'
@@ -73,13 +74,17 @@ module.exports = class Channel
         log.debug 'fetching pvt'
         opts =
             method: 'GET'
-            uri: "#{ORIGIN_URL}/talkgadget/_/extension-start"
+            uri: "#{ORIGIN_URL}/webchat/start"
             jar: request.jar @jarstore
             withCredentials: true
         req(opts).then (res) =>
-            data = JSON.parse res.body
-            log.debug 'found pvt token', data[1]
-            data[1]
+            DICT =
+                pvtToken: { key:'ds:0',  fn: (d) -> d[1] }
+
+            result = []
+            await InitDataParser.parse res.body, DICT, result
+            log.debug 'found pvt token', result.pvtToken
+            result.pvtToken
         .fail (err) ->
             log.info 'fetchPvt failed', fmterr(err)
             Q.reject err

--- a/src/init.coffee
+++ b/src/init.coffee
@@ -36,26 +36,29 @@ module.exports = class Init
         self = @
         req(opts).then (res) =>
             if res.statusCode == 200
-                DICT =
-                    apikey: { name:'cin:cac',  fn: (d) -> d[0][2] }
-                    email:  { name:'cic:vd', fn: (d) -> d[0][2] }
-                    headerdate:    { name:'cin:acc', fn: (d) -> d[0][4] }
-                    headerversion: { name:'cin:acc', fn: (d) -> d[0][6] }
-                    headerid:      { name:'cin:bcsc', fn: (d) -> d[0][7] }
-                    timestamp:     { name:'cgsirp', fn: (d) -> new Date (d[0][1][4] / 1000) }
-                    self_entity:   { name:'cgsirp', fn: (d) ->
-                        CLIENT_GET_SELF_INFO_RESPONSE.parse(d[0]).self_entity
-                    }
-                    conv_states: { name:'cgsirp', fn: (d) ->
-                        # Removed in server-side update
-                        CLIENT_CONVERSATION_STATE_LIST.parse(d[0][3])
-                    }
-
-                await InitDataParser.parse res.body, DICT, this
-
-                # massage the entities
-                this.entgroups = []
-                this.entities = undefined
+                @parseBody res.body
             else
                 log.warn 'init failed', res.statusCode, res.statusMessage
                 Q.reject NetworkError.forRes(res)
+
+    parseBody: (body) ->
+        DICT =
+            apikey: { name:'cin:cac',  fn: (d) -> d[0][2] }
+            email:  { name:'cic:vd', fn: (d) -> d[0][2] }
+            headerdate:    { name:'cin:acc', fn: (d) -> d[0][4] }
+            headerversion: { name:'cin:acc', fn: (d) -> d[0][6] }
+            headerid:      { name:'cin:bcsc', fn: (d) -> d[0][7] }
+            timestamp:     { name:'cgsirp', fn: (d) -> new Date (d[0][1][4] / 1000) }
+            self_entity:   { name:'cgsirp', fn: (d) ->
+                CLIENT_GET_SELF_INFO_RESPONSE.parse(d[0]).self_entity
+            }
+            conv_states: { name:'cgsirp', fn: (d) ->
+                # Removed in server-side update
+                CLIENT_CONVERSATION_STATE_LIST.parse(d[0][3])
+            }
+
+        await InitDataParser.parse body, DICT, this
+
+        # massage the entities
+        this.entgroups = []
+        this.entities = undefined

--- a/src/init.coffee
+++ b/src/init.coffee
@@ -4,6 +4,8 @@ Q       = require 'q'
 fs      = require 'fs'
 syspath = require 'path'
 
+InitDataParser = require './initdataparser'
+
 {req, find, uniqfn, NetworkError} = require './util'
 
 {CLIENT_GET_SELF_INFO_RESPONSE,
@@ -34,87 +36,26 @@ module.exports = class Init
         self = @
         req(opts).then (res) =>
             if res.statusCode == 200
-                self.parseBody res.body
+                DICT =
+                    apikey: { name:'cin:cac',  fn: (d) -> d[0][2] }
+                    email:  { name:'cic:vd', fn: (d) -> d[0][2] }
+                    headerdate:    { name:'cin:acc', fn: (d) -> d[0][4] }
+                    headerversion: { name:'cin:acc', fn: (d) -> d[0][6] }
+                    headerid:      { name:'cin:bcsc', fn: (d) -> d[0][7] }
+                    timestamp:     { name:'cgsirp', fn: (d) -> new Date (d[0][1][4] / 1000) }
+                    self_entity:   { name:'cgsirp', fn: (d) ->
+                        CLIENT_GET_SELF_INFO_RESPONSE.parse(d[0]).self_entity
+                    }
+                    conv_states: { name:'cgsirp', fn: (d) ->
+                        # Removed in server-side update
+                        CLIENT_CONVERSATION_STATE_LIST.parse(d[0][3])
+                    }
+
+                await InitDataParser.parse res.body, DICT, this
+
+                # massage the entities
+                this.entgroups = []
+                this.entities = undefined
             else
                 log.warn 'init failed', res.statusCode, res.statusMessage
                 Q.reject NetworkError.forRes(res)
-
-    parseBody: (body) ->
-        self = @
-        Q().then ->
-            # the structure of the html body is (bizarelly):
-            # <script>...</script>
-            # <script>...</script>
-            # <script>...</script>
-            # <!DOCTYPE html><html>...</html>
-            # <script>...</script>
-            # <script>...</script>
-
-            # first remove the <html> part
-            html = body.replace /<!DOCTYPE html><html>(.|\n)*<\/html>/gm, ''
-
-            # and then the <script> tags
-            html = html.replace /<\/?script.*>/gm, ''
-
-            # expose the init chunk queue
-            html = html.replace 'var AF_initDataChunkQueue =',
-                'var AF_initDataChunkQueue = this.AF_initDataChunkQueue ='
-
-            # eval it.
-            # eval is a security risk, google could inject random
-            # data into our client right here.
-            do (-> eval html).bind(out = {})
-
-            # and return the exposed data
-            return out
-        .then (out) =>
-            # the page has a weird and wonderful javascript structure in
-            # out.AF_initDataChunkQueue =
-            # [ { key: 'ds:0', isError: false, hash: '2', data: [Function] },
-            #   { key: 'ds:1', isError: false, hash: '26', data: [Function] },
-            #   { key: 'ds:2', isError: false, hash: '19', data: [Function] },
-            #   { key: 'ds:3', isError: false, hash: '5', data: [Function] }...
-            DICT =
-                apikey: { name:'cin:cac',  fn: (d) -> d[0][2] }
-                email:  { name:'cic:vd', fn: (d) -> d[0][2] }
-                headerdate:    { name:'cin:acc', fn: (d) -> d[0][4] }
-                headerversion: { name:'cin:acc', fn: (d) -> d[0][6] }
-                headerid:      { name:'cin:bcsc', fn: (d) -> d[0][7] }
-                timestamp:     { name:'cgsirp', fn: (d) -> new Date (d[0][1][4] / 1000) }
-                self_entity:   { name:'cgsirp', fn: (d) ->
-                    CLIENT_GET_SELF_INFO_RESPONSE.parse(d[0]).self_entity
-                }
-                conv_states: { name:'cgsirp', fn: (d) ->
-                    # Removed in server-side update
-                    CLIENT_CONVERSATION_STATE_LIST.parse(d[0][3])
-                }
-
-            for k, spec of DICT
-                ent = find out.AF_initDataChunkQueue, (e) ->
-                    if spec.name? && typeof e.data == 'function'
-                        d = e.data()
-                        if d? && d.length > 0 && d[0].length > 0 && d[0][0].length > 0
-                            return spec.name == d[0][0]
-                    else if spec.name? && Array.isArray e.data
-                        d = e.data
-                        if d? && d.length > 0 && d[0].length > 0 && d[0][0].length > 0
-                            return spec.name == d[0][0]
-                    spec.key == e.key
-
-                if ent
-                    if typeof ent.data == 'function'
-                        data = ent.data()
-                    else
-                        data = ent.data
-
-                    this[k] = d = spec.fn data
-                    if d.length
-                        log.debug 'init data count', k, d.length
-                    else
-                        log.debug 'init data', k, d
-                else
-                    log.warn 'no init data for', k
-
-            # massage the entities
-            entgroups = []
-            self.entities = undefined

--- a/src/initdataparser.coffee
+++ b/src/initdataparser.coffee
@@ -1,0 +1,79 @@
+request = require 'request'
+log     = require 'bog'
+Q       = require 'q'
+fs      = require 'fs'
+syspath = require 'path'
+
+{req, find, uniqfn, NetworkError} = require './util'
+
+{CLIENT_GET_SELF_INFO_RESPONSE,
+CLIENT_CONVERSATION_STATE_LIST,
+INITIAL_CLIENT_ENTITIES} = require './schema'
+
+CHAT_INIT_URL = 'https://hangouts.google.com/webchat/u/0/load'
+CHAT_INIT_PARAMS =
+    fid:  'gtn-roster-iframe-id',
+    ec:   '["ci:ec",true,true,false]',
+    pvt:  null,  # Populated later
+
+module.exports = class InitDataParser
+
+    @parse: (body, dict, result) ->
+        Q().then ->
+            # the structure of the html body is (bizarelly):
+            # <script>...</script>
+            # <script>...</script>
+            # <script>...</script>
+            # <!DOCTYPE html><html>...</html>
+            # <script>...</script>
+            # <script>...</script>
+
+            # first remove the <html> part
+            html = body.replace /<!DOCTYPE html><html>*(.|\n)*<\/html>/gm, ''
+
+            # and then the <script> tags
+            html = html.replace /<\/?script.*>/gm, ''
+
+            # expose the init chunk queue
+            html = html.replace 'var AF_initDataChunkQueue =',
+                'var AF_initDataChunkQueue = this.AF_initDataChunkQueue ='
+
+            # eval it.
+            # eval is a security risk, google could inject random
+            # data into our client right here.
+            do (-> eval html).bind(out = {})
+
+            # and return the exposed data
+            return out
+        .then (out) =>
+            # the page has a weird and wonderful javascript structure in
+            # out.AF_initDataChunkQueue =
+            # [ { key: 'ds:0', isError: false, hash: '2', data: [Function] },
+            #   { key: 'ds:1', isError: false, hash: '26', data: [Function] },
+            #   { key: 'ds:2', isError: false, hash: '19', data: [Function] },
+            #   { key: 'ds:3', isError: false, hash: '5', data: [Function] }...
+            for k, spec of dict
+                ent = find out.AF_initDataChunkQueue, (e) ->
+                    if spec.name? && typeof e.data == 'function'
+                        d = e.data()
+                        if d? && d.length > 0 && d[0].length > 0 && d[0][0].length > 0
+                            return spec.name == d[0][0]
+                    else if spec.name? && Array.isArray e.data
+                        d = e.data
+                        if d? && d.length > 0 && d[0].length > 0 && d[0][0].length > 0
+                            return spec.name == d[0][0]
+                    spec.key == e.key
+
+                if ent
+                    if typeof ent.data == 'function'
+                        data = ent.data()
+                    else
+                        data = ent.data
+
+                    result[k] = d = spec.fn data
+                    if d.length
+                        log.debug 'init data count', k, d.length
+                    else
+                        log.debug 'init data', k, d
+                else
+                    log.warn 'no init data for', k

--- a/src/initdataparser.coffee
+++ b/src/initdataparser.coffee
@@ -1,20 +1,7 @@
-request = require 'request'
 log     = require 'bog'
 Q       = require 'q'
-fs      = require 'fs'
-syspath = require 'path'
 
-{req, find, uniqfn, NetworkError} = require './util'
-
-{CLIENT_GET_SELF_INFO_RESPONSE,
-CLIENT_CONVERSATION_STATE_LIST,
-INITIAL_CLIENT_ENTITIES} = require './schema'
-
-CHAT_INIT_URL = 'https://hangouts.google.com/webchat/u/0/load'
-CHAT_INIT_PARAMS =
-    fid:  'gtn-roster-iframe-id',
-    ec:   '["ci:ec",true,true,false]',
-    pvt:  null,  # Populated later
+{find} = require './util'
 
 module.exports = class InitDataParser
 


### PR DESCRIPTION
This is due to the /talkgadget/_/extension-start page being removed. We're now using /webchat/start instead and an init data parser.