### PR TITLE
Parse more responses

### DIFF
--- a/src/client.coffee
+++ b/src/client.coffee
@@ -25,6 +25,7 @@ ClientNotificationLevel,
 CLIENT_SYNC_ALL_NEW_EVENTS_RESPONSE,
 CLIENT_GET_CONVERSATION_RESPONSE,
 CLIENT_GET_ENTITY_BY_ID_RESPONSE,
+CLIENT_CREATE_CONVERSATION_RESPONSE,
 CLIENT_SEARCH_ENTITIES_RESPONSE} = require './schema'
 
 IMAGE_UPLOAD_URL = 'https://docs.google.com/upload/photos/resumable'
@@ -448,16 +449,17 @@ module.exports = class Client extends EventEmitter
     # force_group set to true if you invite just one chat_id, but
     # still want a group.
     #
-    # New conversation ID is returned as res['conversation']['id']['id']
+    # New conversation ID is returned as res['conversation']['conversation_id']['id']
     createconversation: (chat_ids, force_group=false) ->
         client_generated_id = randomid()
-        @chatreq.req 'conversations/createconversation', [
+        @chatreq.req('conversations/createconversation', [
             @_requestBodyHeader()
             if chat_ids.length == 1 and not force_group then 1 else 2
             client_generated_id
             None
             [chat_id, None, None, "unknown", None, []] for chat_id in chat_ids
-        ]
+        ], false).then (body) ->
+            CLIENT_CREATE_CONVERSATION_RESPONSE.parse body
 
 
     # Return conversation events.

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -23,8 +23,9 @@ MessageActionType,
 ClientDeliveryMediumType,
 ClientNotificationLevel,
 CLIENT_SYNC_ALL_NEW_EVENTS_RESPONSE,
-CLIENT_GET_CONVERSATION_RESPONSE
-CLIENT_GET_ENTITY_BY_ID_RESPONSE} = require './schema'
+CLIENT_GET_CONVERSATION_RESPONSE,
+CLIENT_GET_ENTITY_BY_ID_RESPONSE,
+CLIENT_SEARCH_ENTITIES_RESPONSE} = require './schema'
 
 IMAGE_UPLOAD_URL = 'https://docs.google.com/upload/photos/resumable'
 
@@ -508,12 +509,13 @@ module.exports = class Client extends EventEmitter
 
     # Search for people.
     searchentities: (search_string, max_results=10) ->
-        @chatreq.req 'contacts/searchentities', [
+        @chatreq.req('contacts/searchentities', [
             @_requestBodyHeader()
             []
             search_string
             max_results
-        ]
+        ], false).then (body) ->
+            CLIENT_SEARCH_ENTITIES_RESPONSE.parse body
 
 
     # Return information about a list of chat_ids

--- a/src/schema.coffee
+++ b/src/schema.coffee
@@ -515,4 +515,10 @@ s.CLIENT_GET_ENTITY_BY_ID_RESPONSE = new Message([
     'entities', new RepeatedField(s.CLIENT_ENTITY)
 ])
 
+s.CLIENT_SEARCH_ENTITIES_RESPONSE = new Message([
+    None, new Field() # 'ResponseHeader'
+    'response_header', s.CLIENT_RESPONSE_HEADER
+    'entity', new RepeatedField(s.CLIENT_ENTITY)
+])
+
 module.exports = s

--- a/src/schema.coffee
+++ b/src/schema.coffee
@@ -515,8 +515,14 @@ s.CLIENT_GET_ENTITY_BY_ID_RESPONSE = new Message([
     'entities', new RepeatedField(s.CLIENT_ENTITY)
 ])
 
+s.CLIENT_CREATE_CONVERSATION_RESPONSE = new Message([
+    None, new Field()
+    'response_header', s.CLIENT_RESPONSE_HEADER
+    'conversation', s.CLIENT_CONVERSATION
+])
+
 s.CLIENT_SEARCH_ENTITIES_RESPONSE = new Message([
-    None, new Field() # 'ResponseHeader'
+    None, new Field()
     'response_header', s.CLIENT_RESPONSE_HEADER
     'entity', new RepeatedField(s.CLIENT_ENTITY)
 ])


### PR DESCRIPTION
This adds parsing for more responses to fix issues with creating new conversations and all names showing up as Unknown.

Note that this is a breaking change as it changes the response of createconversation to use conversation.conversation_id instead of conversation.id.