### PR TITLE
Fix private token not being fetched anymore, causing login to fail

### DIFF
--- a/src/initdataparser.coffee
+++ b/src/initdataparser.coffee
@@ -19,7 +19,7 @@ module.exports = class InitDataParser
             html = body.replace /<!DOCTYPE html><html>*(.|\n)*<\/html>/gm, ''
 
             # and then the <script> tags
-            html = html.replace /<\/?script.*>/gm, ''
+            html = html.replace /<\/?script.*?>/gm, ''
 
             # expose the init chunk queue
             html = html.replace 'var AF_initDataChunkQueue =',


### PR DESCRIPTION
This was because google now use multiple script tags in the response, which caused only the first one to be included. This was fixed by using a lazy regex instead of greedy (*? instead of just *).